### PR TITLE
Fix bank-vaults hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ matter which provider you use.
 | ------------------------------------------------------------- | -------- | --- | ----- | --- | ----- | --------- | ------- |
 | 🤫 Murmur                                                     | ✅       | ✅  | ✅    | ✅  | ❌    | ❌        | ❌      |
 | [Berglas](https://github.com/GoogleCloudPlatform/berglas)     | ❌       | ❌  | ❌    | ✅  | ❌    | ❌        | ❌      |
-| [Bank Vaults](https://github.com/GoogleCloudPlatform/berglas) | ❌       | ❌  | ❌    | ❌  | ✅    | ❌        | ❌      |
+| [Bank Vaults](https://github.com/banzaicloud/bank-vaults)     | ❌       | ❌  | ❌    | ❌  | ✅    | ❌        | ❌      |
 | [1Password CLI](https://developer.1password.com/docs/cli/)    | ❌       | ❌  | ❌    | ❌  | ❌    | ✅        | ❌      |
 | [Doppler CLI](https://github.com/DopplerHQ/cli)               | ❌       | ❌  | ❌    | ❌  | ❌    | ❌        | ✅      |
 


### PR DESCRIPTION
I wanted to check out the Vault executable, but was redirected to the berglas github page instead.

Please verify this is indeed the correct url, as I'm unfamiliar with all of these except the 1Password CLI.