### PR TITLE
🔐 Improve GCP workload identity config security

### DIFF
--- a/terraform/layers/gcp-secret-manager/github_actions.tf
+++ b/terraform/layers/gcp-secret-manager/github_actions.tf
@@ -33,6 +33,8 @@ resource "google_iam_workload_identity_pool_provider" "github_oidc" {
     "attribute.repository" = "assertion.repository"
   }
 
+  attribute_condition = "attribute.repository == 'busser/murmur'"
+
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"
   }


### PR DESCRIPTION
GCP sent me a notification warning me about a potentially insecure workload identity configuration. The configuration wasn't vulnerable but the recommendations were good so I implemented them.