### PR TITLE
🐛 Fix broken Terraform backend config

### DIFF
--- a/terraform/layers/aws-secrets-manager/_settings.tf
+++ b/terraform/layers/aws-secrets-manager/_settings.tf
@@ -25,6 +25,7 @@ terraform {
     # skip certain validation steps.
     skip_credentials_validation = true
     skip_region_validation      = true
+    skip_requesting_account_id  = true
   }
 
   # This layer requires that certain providers be configured by the caller.

--- a/terraform/layers/azure-keyvault/_settings.tf
+++ b/terraform/layers/azure-keyvault/_settings.tf
@@ -25,6 +25,7 @@ terraform {
     # skip certain validation steps.
     skip_credentials_validation = true
     skip_region_validation      = true
+    skip_requesting_account_id  = true
   }
 
   # This layer requires that certain providers be configured by the caller.

--- a/terraform/layers/gcp-secret-manager/_settings.tf
+++ b/terraform/layers/gcp-secret-manager/_settings.tf
@@ -25,6 +25,7 @@ terraform {
     # skip certain validation steps.
     skip_credentials_validation = true
     skip_region_validation      = true
+    skip_requesting_account_id  = true
   }
 
   # This layer requires that certain providers be configured by the caller.

--- a/terraform/layers/scw-secret-manager/_settings.tf
+++ b/terraform/layers/scw-secret-manager/_settings.tf
@@ -25,6 +25,7 @@ terraform {
     # skip certain validation steps.
     skip_credentials_validation = true
     skip_region_validation      = true
+    skip_requesting_account_id  = true
   }
 
   # This layer requires that certain providers be configured by the caller.


### PR DESCRIPTION
It looks like there was an update to the `s3` Terraform backend that
broke its ability to connect to Scaleway's S3 API. This PR fixes the
problem so that we can use Terraform again.
