### PR TITLE
🧹 Fix end-to-end test setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Development
+- **Format code**: `make fmt` or `go fmt ./...`
+- **Vet code**: `make vet` or `go vet ./...`  
+- **Run unit tests**: `make test` or `go test ./...`
+- **Run all tests (including e2e)**: `make test-e2e` or `go test -tags=e2e ./...`
+- **Build binary**: `make build` (outputs to `bin/murmur`)
+
+### Testing
+- Run specific test: `go test ./path/to/package -run TestName`
+- Run e2e tests for specific provider: `go test -tags=e2e ./internal/murmur/providers/awssm`
+
+## Architecture
+
+Murmur is a secrets injection tool that fetches secrets from various cloud providers and injects them as environment variables for subprocesses.
+
+### Core Components
+
+**Command Structure**: 
+- `main.go` → `internal/cmd/` → `internal/murmur/`
+- Primary commands: `run` (preferred) and `exec` (deprecated)
+
+**Provider System** (`internal/murmur/providers/`):
+- Each provider implements the `Provider` interface with `Resolve()` and `Close()` methods
+- Supported providers: `awssm` (AWS Secrets Manager), `azkv` (Azure Key Vault), `gcpsm` (GCP Secret Manager), `scwsm` (Scaleway Secret Manager), `passthrough` (testing)
+- Provider registration in `provider.go` via `ProviderFactories` map
+
+**Query Processing Pipeline** (`resolve.go`):
+1. **Parse**: Environment variables → query objects (`provider_id:secret_ref|filter_id:filter_rule`)
+2. **Resolve**: Fetch secrets from providers (concurrent by provider, cached for duplicates)
+3. **Filter**: Apply transformations like JSONPath parsing
+4. **Output**: Final environment variables for subprocess
+
+**Filter System** (`filter.go`, `filters/`):
+- Currently supports `jsonpath` filter using Kubernetes JSONPath syntax
+- Filters transform raw secret values (e.g., extract fields from JSON secrets)
+
+### Key Design Patterns
+
+- **Concurrent processing**: Secrets are fetched concurrently per provider to minimize latency
+- **Caching**: Duplicate secret references are cached to avoid redundant API calls  
+- **Pipeline architecture**: Variable processing flows through parse → resolve → filter stages
+- **Provider isolation**: Each cloud provider is completely isolated in its own package
+
+### Testing Structure
+
+- Unit tests alongside source files (`*_test.go`)
+- E2E tests require `-tags=e2e` flag and real cloud credentials
+- Mock providers available for testing (`providers/mock/`, `providers/jsonmock/`)
+- Test data in `internal/murmur/testdata/`

--- a/terraform/layers/aws-secrets-manager/_settings.tf
+++ b/terraform/layers/aws-secrets-manager/_settings.tf
@@ -16,11 +16,13 @@ terraform {
   # For more information on state backends: https://www.terraform.io/docs/language/settings/backends/index.html
   # For more information on the "s3" backend: https://www.terraform.io/docs/language/settings/backends/s3.html
   backend "s3" {
-    bucket   = "busser-murmur-tfstate"
-    key      = "aws-secrets-manager"
-    region   = "fr-par"
-    endpoint = "https://s3.fr-par.scw.cloud"
-    profile  = "scaleway"
+    bucket = "busser-murmur-tfstate"
+    key    = "aws-secrets-manager"
+    region = "fr-par"
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
+    profile = "scaleway"
     # We are swapping the AWS S3 API for the Scaleway S3 API, so we need to 
     # skip certain validation steps.
     skip_credentials_validation = true

--- a/terraform/layers/azure-keyvault/_providers.tf
+++ b/terraform/layers/azure-keyvault/_providers.tf
@@ -10,8 +10,7 @@ provider "azurerm" {
   subscription_id = "8ab3da27-5e1b-494f-abc6-726fb04729b3"
 
   # We don't need to register any resource providers.
-  # For more information: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#skip_provider_registration
-  skip_provider_registration = false
+  resource_provider_registrations = "none"
 }
 
 # The "azuread" provider enables us to provision resources in Azure Active

--- a/terraform/layers/azure-keyvault/_settings.tf
+++ b/terraform/layers/azure-keyvault/_settings.tf
@@ -16,11 +16,13 @@ terraform {
   # For more information on state backends: https://www.terraform.io/docs/language/settings/backends/index.html
   # For more information on the "s3" backend: https://www.terraform.io/docs/language/settings/backends/s3.html
   backend "s3" {
-    bucket   = "busser-murmur-tfstate"
-    key      = "azurerm-keyvault"
-    region   = "fr-par"
-    endpoint = "https://s3.fr-par.scw.cloud"
-    profile  = "scaleway"
+    bucket = "busser-murmur-tfstate"
+    key    = "azurerm-keyvault"
+    region = "fr-par"
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
+    profile = "scaleway"
     # We are swapping the AWS S3 API for the Scaleway S3 API, so we need to 
     # skip certain validation steps.
     skip_credentials_validation = true
@@ -33,15 +35,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.58.0"
+      version = "4.32.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "2.39.0"
+      version = "3.4.0"
     }
     github = {
       source  = "integrations/github"
-      version = "6.2.1"
+      version = "6.6.0"
     }
   }
 }

--- a/terraform/layers/azure-keyvault/github_actions.tf
+++ b/terraform/layers/azure-keyvault/github_actions.tf
@@ -10,13 +10,13 @@ resource "azuread_application" "github_actions" {
 }
 
 resource "azuread_service_principal" "github_actions" {
-  application_id               = azuread_application.github_actions.application_id
+  client_id                    = azuread_application.github_actions.client_id
   app_role_assignment_required = false
   owners                       = [data.azuread_client_config.current.object_id]
 }
 
 resource "azuread_service_principal_password" "github_actions" {
-  service_principal_id = azuread_service_principal.github_actions.object_id
+  service_principal_id = azuread_service_principal.github_actions.id
 }
 
 // The necessary credentials are stored in this repository's Github Actions
@@ -36,7 +36,7 @@ resource "github_actions_secret" "tenant_id" {
 resource "github_actions_secret" "client_id" {
   repository      = data.github_repository.murmur.name
   secret_name     = "AZURE_CLIENT_ID"
-  plaintext_value = azuread_service_principal.github_actions.application_id
+  plaintext_value = azuread_service_principal.github_actions.client_id
 }
 
 resource "github_actions_secret" "client_secret" {

--- a/terraform/layers/gcp-secret-manager/_settings.tf
+++ b/terraform/layers/gcp-secret-manager/_settings.tf
@@ -16,11 +16,13 @@ terraform {
   # For more information on state backends: https://www.terraform.io/docs/language/settings/backends/index.html
   # For more information on the "s3" backend: https://www.terraform.io/docs/language/settings/backends/s3.html
   backend "s3" {
-    bucket   = "busser-murmur-tfstate"
-    key      = "gcp-secret-manager"
-    region   = "fr-par"
-    endpoint = "https://s3.fr-par.scw.cloud"
-    profile  = "scaleway"
+    bucket = "busser-murmur-tfstate"
+    key    = "gcp-secret-manager"
+    region = "fr-par"
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
+    profile = "scaleway"
     # We are swapping the AWS S3 API for the Scaleway S3 API, so we need to 
     # skip certain validation steps.
     skip_credentials_validation = true

--- a/terraform/layers/scw-secret-manager/_settings.tf
+++ b/terraform/layers/scw-secret-manager/_settings.tf
@@ -16,11 +16,13 @@ terraform {
   # For more information on state backends: https://www.terraform.io/docs/language/settings/backends/index.html
   # For more information on the "s3" backend: https://www.terraform.io/docs/language/settings/backends/s3.html
   backend "s3" {
-    bucket   = "busser-murmur-tfstate"
-    key      = "scw-secret-manager"
-    region   = "fr-par"
-    endpoint = "https://s3.fr-par.scw.cloud"
-    profile  = "scaleway"
+    bucket = "busser-murmur-tfstate"
+    key    = "scw-secret-manager"
+    region = "fr-par"
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
+    profile = "scaleway"
     # We are swapping the AWS S3 API for the Scaleway S3 API, so we need to 
     # skip certain validation steps.
     skip_credentials_validation = true


### PR DESCRIPTION
It's been a while since I've worked on Murmur. Its end-to-end test setup seems
to have broken a bit over time. This PR fixes it.

The core issue seems to have been that Azure credentials used by our CI expired.
Fixing this required fixing some of our Terraform code because of breaking
changes in some providers.